### PR TITLE
add .DS_Strore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 
 .idea/
 /*/build/
+.DS_Store


### PR DESCRIPTION
В Mac OS finder создает файлы .DS_Store, которые не нужно добавлять в гит, что бы не править .gitignore каждому пользователю Mac локально, предлагаю добавить это в основной репозиторий