### PR TITLE
Bar collision tests

### DIFF
--- a/lecture02/src/test/java/ru/atom/geometry/BarBarCollisionTest.java
+++ b/lecture02/src/test/java/ru/atom/geometry/BarBarCollisionTest.java
@@ -149,7 +149,7 @@ public class BarBarCollisionTest {
     }
 
     @Test
-    public void barIntersectsBar14() {
+    public void barIntersectsBar4() {
         Collider bar1 = Geometry.createBar(50, 0, 150, 100);
         Collider bar2 = Geometry.createBar(0, 0, 100, 100);
         assertTrue(bar1.isColliding(bar2));
@@ -167,6 +167,27 @@ public class BarBarCollisionTest {
         Collider bar1 = Geometry.createBar(50, 50, 150, 150);
         Collider bar2 = Geometry.createBar(0, 0, 100, 100);
         assertTrue(bar1.isColliding(bar2));
+    }
+
+    @Test
+    public void barIntersectsBar7() {
+        Collider bar1 = Geometry.createBar(-50, 50, 50, 150);
+        Collider bar2 = Geometry.createBar(0, 0, 100, 100);
+        assertTrue(bar1.isColliding(bar2));
+    }
+
+    @Test
+    public void barIntersectsBar8() {
+        Collider bar1 = Geometry.createBar(-50, 50, 50, 150);
+        Collider bar2 = Geometry.createBar(0, 0, 100, 100);
+        assertTrue(bar2.isColliding(bar1));
+    }
+
+    @Test
+    public void barIntersectsBar9() {
+        Collider bar1 = Geometry.createBar(50, 50, 150, 150);
+        Collider bar2 = Geometry.createBar(0, 0, 100, 100);
+        assertTrue(bar2.isColliding(bar1));
     }
 
     @Test
@@ -188,6 +209,13 @@ public class BarBarCollisionTest {
         Collider bar1 = Geometry.createBar(0, 0, 200, 200);
         Collider bar2 = Geometry.createBar(50, 50, 150, 150);
         assertTrue(bar1.isColliding(bar2));
+    }
+
+    @Test
+    public void barIncludesBar2() {
+        Collider bar1 = Geometry.createBar(0, 0, 200, 200);
+        Collider bar2 = Geometry.createBar(50, 50, 150, 150);
+        assertTrue(bar2.isColliding(bar1));
     }
 
     @Test


### PR DESCRIPTION
Добавил пару тестов. На пересечение были только такие кейсы:
![screenshot from 2018-03-05 18-30-52](https://user-images.githubusercontent.com/25932451/36983711-24c0879e-20a4-11e8-9160-8b79c3db5c01.png)
Я добавил такой:
![screenshot from 2018-03-05 18-31-23](https://user-images.githubusercontent.com/25932451/36983728-30dfcb2a-20a4-11e8-84fe-41c863a655e7.png)
Теперь не будут проходить неадекватные решения типа:
`if (o instanceof Bar) {
            return (this.isColliding(((Bar) o).getTop()) || this.isColliding(((Bar) o).getBottom())
                    || o.isColliding(this.top) || o.isColliding(this.bottom));
        }`
Кому-нибудь может захотеться проверять пересечение всех точек одного бара с другим - это почти верно, кроме случая, когда один включает в себя другой, такой кейс был, но проверялось только:
`bar1.isColliding(bar2)`, что может сработать, в зависимости от такого точки какого бара брать, так что хочется `bar1.isColliding(bar2) && bar2.isColliding(bar1)`. Да и вообще, хотелось бы такое условие поставить во всех тестах на всякий случай, но, полагаю, это будет нарушать какой-нибудь из принципов unit-тестирования, так что запилил отдельный.