### PR TITLE
logger collision fix

### DIFF
--- a/lecture06/build.gradle
+++ b/lecture06/build.gradle
@@ -8,8 +8,12 @@ dependencies {
     testCompile rootProject.libraries.spring_boot_test
 }
 
+configurations {
+    compile.exclude group:'ch.qos.logback'
+}
+
 springBoot {
-    mainClass = "ru.atom.lecture06.servcer.ChatApplication"
+    mainClass = "ru.atom.lecture06.server.ChatApplication"
 }
 
 


### PR DESCRIPTION
Конфликт случался из-за наличия двух плагинов использующих логгирование: spring-boot-starter-web и log4j, которые используюют разные источники, мы исключаем из classpath Logback добавленный туда спринг бутом и оставляем log4j 