### PR TITLE
fix frontend

### DIFF
--- a/bomberman/frontend/src/main/webapp/js/Message.js
+++ b/bomberman/frontend/src/main/webapp/js/Message.js
@@ -30,7 +30,8 @@ Messages = Class.extend({
 
 
     handleReplica: function (msg) {
-        var gameObjects = JSON.parse(msg.data).objects;
+        //var gameObjects = JSON.parse(msg.data).objects
+        var gameObjects = msg.data.objects;
         var survivors = new Set();
 
         for (var i = 0; i < gameObjects.length; i++) {
@@ -84,7 +85,8 @@ Messages = Class.extend({
             return el.id === obj.id;
         });
 
-        var position = Utils.getEntityPosition(Utils.convertToBitmapPosition(obj.position));
+        //var position = Utils.getEntityPosition(Utils.convertToBitmapPosition(obj.position));
+        var position = Utils.getEntityPosition(obj.position);
         if (tile) {
             tile.material = obj.type;
         } else {

--- a/bomberman/frontend/src/main/webapp/js/ServerProxy.js
+++ b/bomberman/frontend/src/main/webapp/js/ServerProxy.js
@@ -52,7 +52,7 @@ ServerProxy = Class.extend({
                 console.log("Matchmaker request failed, use default gameId=" + that.gameId);
                 that.connectToGameServer(that.gameId, login);
             },
-            processData: false,
+            //processData: false
             type: 'POST',
             url: that.matchMakerUrl
         });


### PR DESCRIPTION
3 фикса фронтенда. Возникали ошибки при работе в Firefox 56.0 и Chrome 62.0, в других не тестил, но скорее всего то же самое.
1) Message.js, функция handleReplica.
 Поскольку js воспринимает часть приходящего json не как строку, а как объект, то попытка парсить из несуществующей строки в объект все ломает.
2)  Message.js, функция handleTile. В моем понимании, этот метод размещает статические объекты (стены и коробки как минимум), но делает это отличным от размещения игроков, огня и бомб способом. Как результат, стены и коробки ставятся в некорректные позиции.
3) ProxyServer.js, функция getSessionIdFromMatchMaker. processData: false запрещает преобразование строки формата key1=value1&key2=value2 в строку {key1: 'value1', key2: 'value2'}. Казалось бы это то, что действительно надо сделать, но почему-то на бэкэнд в таком случае приходят некорректные данные. Возможно потому, что стоит изменить настройку contentType с application/x-www-form-urlencoded на что-то другое (так пишут в интернетах), но точно сказать не могу.
