### PR TITLE
Null socket fix

### DIFF
--- a/bomberman/frontend/src/main/webapp/js/ServerProxy.js
+++ b/bomberman/frontend/src/main/webapp/js/ServerProxy.js
@@ -10,23 +10,6 @@ ServerProxy = Class.extend({
     init: function () {
         this.handler['REPLICA'] = gMessages.handleReplica;
         this.handler['POSSESS'] = gMessages.handlePossess;
-
-        var self = this;
-        gInputEngine.subscribe('up', function () {
-            self.socket.send(gMessages.move('up'))
-        });
-        gInputEngine.subscribe('down', function () {
-            self.socket.send(gMessages.move('down'))
-        });
-        gInputEngine.subscribe('left', function () {
-            self.socket.send(gMessages.move('left'))
-        });
-        gInputEngine.subscribe('right', function () {
-            self.socket.send(gMessages.move('right'))
-        });
-        gInputEngine.subscribe('bomb', function () {
-            self.socket.send(gMessages.plantBomb())
-        });
     },
 
     getSessionIdFromMatchMaker: function () {
@@ -55,6 +38,27 @@ ServerProxy = Class.extend({
             //processData: false
             type: 'POST',
             url: that.matchMakerUrl
+        });
+
+        that.subscribeEvents();
+    },
+
+    subscribeEvents: function () {
+        var self = this;
+        gInputEngine.subscribe('up', function () {
+            self.socket.send(gMessages.move('up'))
+        });
+        gInputEngine.subscribe('down', function () {
+            self.socket.send(gMessages.move('down'))
+        });
+        gInputEngine.subscribe('left', function () {
+            self.socket.send(gMessages.move('left'))
+        });
+        gInputEngine.subscribe('right', function () {
+            self.socket.send(gMessages.move('right'))
+        });
+        gInputEngine.subscribe('bomb', function () {
+            self.socket.send(gMessages.plantBomb())
         });
     },
 


### PR DESCRIPTION
Как известно, "Cannot read property 'send' of null" переводится, как socket == null, почему он null?Потому что мы создаем два ServerProxy (для меня неочевидно зачем, но что-то вроде того, что один создается при загрузке страницы в GameEngine.setup, скорее всего preload.js'ом, а второй при нажатии на кнопку в GameEngine.restart()) socket же инициализирован только во втором случае. После фикса мы сабскрайбим действия (нажатия клавиш) не в ServerProxy.init(), а только после инициализации сокета.